### PR TITLE
SWIT-3073

### DIFF
--- a/review/developer/pr-descriptions.md
+++ b/review/developer/pr-descriptions.md
@@ -137,4 +137,4 @@ PRs can undergo significant change during review. It can be worthwhile to review
 a PR description before submitting the PR, to ensure that the description still
 reflects what the PR does.
 
-Next: [Small CLs](small-cls.md)
+Next: [Small PRs](small-prs.md)

--- a/review/developer/small-prs.md
+++ b/review/developer/small-prs.md
@@ -46,9 +46,8 @@ that:
 
 -   The PR makes a minimal change that addresses **just one thing**. This is
     usually just one part of a feature, rather than a whole feature at once. In
-    general it's better to err on the side of writing PRs that are too small vs.
-    PRs that are too large. Work with your reviewer to find out what an
-    acceptable size is.
+    general it's better to err on the side of writing PRs that are too small.
+    Work with your reviewer to find out what an acceptable size is.
 -   The PR should [include related test code](#test_code).
 -   Everything the reviewer needs to understand about the PR (except future
     development) is in the PR, the PR's description, the existing codebase, or a

--- a/review/reviewer/looking-for.md
+++ b/review/reviewer/looking-for.md
@@ -2,6 +2,29 @@
 
 
 
+
+## Summary
+
+In doing a code review, you should make sure that:
+
+-   The code is well-designed.
+-   The functionality is good for the users of the code.
+-   Any UI changes are sensible and look good.
+-   Any parallel programming is done safely.
+-   The code isn't more complex than it needs to be.
+-   The developer isn't implementing things they *might* need in the future but
+    don't know they need now.
+-   Code has appropriate unit tests.
+-   Tests are well-designed.
+-   The developer used clear names for everything.
+-   Comments are clear and useful, and mostly explain *why* instead of *what*.
+-   Code is appropriately documented (generally in READMEs or Confluence Wiki).
+-   The code conforms to our style guides.
+
+Make sure to review **every line** of code you've been asked to review, look at
+the **context**, make sure you're **improving code health**, and compliment
+developers on **good things** that they do.
+
 Note: Always make sure to take into account
 [The Standard of Code Review](standard.md) when considering each of these
 points.
@@ -191,27 +214,5 @@ addressed one of your comments in a great way. Code reviews often just focus on
 mistakes, but they should offer encouragement and appreciation for good
 practices, as well. It’s sometimes even more valuable, in terms of mentoring, to
 tell a developer what they did right than to tell them what they did wrong.
-
-## Summary
-
-In doing a code review, you should make sure that:
-
--   The code is well-designed.
--   The functionality is good for the users of the code.
--   Any UI changes are sensible and look good.
--   Any parallel programming is done safely.
--   The code isn't more complex than it needs to be.
--   The developer isn't implementing things they *might* need in the future but
-    don't know they need now.
--   Code has appropriate unit tests.
--   Tests are well-designed.
--   The developer used clear names for everything.
--   Comments are clear and useful, and mostly explain *why* instead of *what*.
--   Code is appropriately documented (generally in READMEs or Confluence Wiki).
--   The code conforms to our style guides.
-
-Make sure to review **every line** of code you've been asked to review, look at
-the **context**, make sure you're **improving code health**, and compliment
-developers on **good things** that they do.
 
 Next: [Navigating a PR in Review](navigate.md)

--- a/review/reviewer/looking-for.md
+++ b/review/reviewer/looking-for.md
@@ -204,7 +204,7 @@ It's also useful to think about the PR in the context of the system as a whole.
 Is this PR improving the code health of the system or is it making the whole
 system more complex, less tested, etc.? **Don't accept PRs that degrade the code
 health of the system.** Most systems become complex through many small changes
-that add up, so it's important to prevent even small unneeded complexities in new
+that add up, so it's important to prevent even small unnecessary complexities in new
 changes.
 
 ## Good Things {#good_things}

--- a/review/reviewer/looking-for.md
+++ b/review/reviewer/looking-for.md
@@ -130,8 +130,7 @@ follow the guidelines.
 
 Otherwise, if the style guideline is more a recommendation and not a
 requirement, then it's a judgment call whether the new code should be consistent
-with the style guide or the surrounding code. Bias towards following the style
-guide unless the local inconsistency would be too confusing.
+with the style guide or the surrounding code.
 
 If no other rule applies, the author should maintain consistency with the
 existing code.
@@ -182,7 +181,7 @@ It's also useful to think about the PR in the context of the system as a whole.
 Is this PR improving the code health of the system or is it making the whole
 system more complex, less tested, etc.? **Don't accept PRs that degrade the code
 health of the system.** Most systems become complex through many small changes
-that add up, so it's important to prevent even small complexities in new
+that add up, so it's important to prevent even small unneeded complexities in new
 changes.
 
 ## Good Things {#good_things}

--- a/review/reviewer/navigate.md
+++ b/review/reviewer/navigate.md
@@ -68,7 +68,7 @@ comments out immediately:
 ## Step Three: Look through the rest of the PR in an appropriate sequence {#step_three}
 
 Once there are no major design problems with the PR as a whole, try to figure out a
-logical sequence to look through the all the files. Usually after you've looked 
+logical sequence to look through all the files. Usually after you've looked 
 through the major files, it's simplest to just go through each file in the order that
 the code review tool presents them to you. Sometimes it's also helpful to read the tests
 first before you read the main code, because then you have an idea of what the

--- a/review/reviewer/navigate.md
+++ b/review/reviewer/navigate.md
@@ -61,19 +61,17 @@ comments out immediately:
     you're reviewing, they're also going to have to re-work their later PR. You
     want to catch them before they've done too much extra work on top of the
     problematic design.
--   Major design changes take longer to do than small changes. Developers nearly
-    all have deadlines; in order to make those deadlines and still have quality
-    code in the codebase, the developer needs to start on any major re-work of
-    the PR as soon as possible.
+-   Major design changes take longer to do than small changes. To make deadlines
+    and produce quality code in the codebase, the developer needs to start on any
+    major re-work of the PR as soon as possible.
 
 ## Step Three: Look through the rest of the PR in an appropriate sequence {#step_three}
 
-Once you've confirmed there are no major design problems with the PR as a whole,
-try to figure out a logical sequence to look through the files while also making
-sure you don't miss reviewing any file. Usually after you've looked through the
-major files, it's simplest to just go through each file in the order that
+Once there are no major design problems with the PR as a whole, try to figure out a
+logical sequence to look through the all the files. Usually after you've looked 
+through the major files, it's simplest to just go through each file in the order that
 the code review tool presents them to you. Sometimes it's also helpful to read the tests
 first before you read the main code, because then you have an idea of what the
-change is supposed to be doing.
+change is supposed to do.
 
 Next: [Speed of Code Reviews](speed.md)

--- a/review/reviewer/pushback.md
+++ b/review/reviewer/pushback.md
@@ -2,11 +2,18 @@
 
 
 
+## Summary
+
+* During a disagreement, a reviewer should consider the perspective of the developer.
+* Reviewers should politely but firmly stand by their suggestion if it improves code health.
+* Upsets are usually more about the way comments are written than about the reviewer’s insistence on code quality.
+* Usually reviewers should insist the PR to be cleaned up now rather than later.
+
+## Who Is Right? {#who_is_right}
+
 Sometimes a developer will push back on a code review. Either they will disagree
 with your suggestion or they will complain that you are being too strict in
 general.
-
-## Who Is Right? {#who_is_right}
 
 When a developer disagrees with your suggestion, first take a moment to consider
 if they are correct. Often, they are closer to the code than you are, and so

--- a/review/reviewer/pushback.md
+++ b/review/reviewer/pushback.md
@@ -4,10 +4,10 @@
 
 ## Summary
 
-* During a disagreement, a reviewer should consider the perspective of the developer.
-* Reviewers should politely but firmly stand by their suggestion if it improves code health.
-* Upsets are usually more about the way comments are written than about the reviewer’s insistence on code quality.
-* Usually reviewers should insist the PR to be cleaned up now rather than later.
+-   During a disagreement, a reviewer should consider the perspective of the developer.
+-   Reviewers should politely but firmly stand by their suggestion if it improves code health.
+-   Upsets are usually more about the way comments are written than about the reviewer’s insistence on code quality.
+-   Usually reviewers should insist the PR to be cleaned up now rather than later.
 
 ## Who Is Right? {#who_is_right}
 

--- a/review/reviewer/speed.md
+++ b/review/reviewer/speed.md
@@ -2,6 +2,13 @@
 
 
 
+## Summary
+
+* Code reviews should be conducted asap without interrupting a focused task.
+* Individual response speed is more important than the overall review process time.
+* Slow individual response speed result in slower overall development 
+* Reviewers should request developlers to split a massive PR into smaller PRs.
+
 ## Why Should Code Reviews Be Fast? {#why}
 
 **At SwitchDin, we optimize for the speed at which a team of developers can produce

--- a/review/reviewer/speed.md
+++ b/review/reviewer/speed.md
@@ -4,10 +4,10 @@
 
 ## Summary
 
-* Code reviews should be conducted asap without interrupting a focused task.
-* Individual response speed is more important than the overall review process time.
-* Slow individual response speed result in slower overall development 
-* Reviewers should request developlers to split a massive PR into smaller PRs.
+-   Code reviews should be conducted asap without interrupting a focused task.
+-   Individual response speed is more important than the overall review process time.
+-   Slow individual response speed result in slower overall development 
+-   Reviewers should request developlers to split a massive PR into smaller PRs.
 
 ## Why Should Code Reviews Be Fast? {#why}
 


### PR DESCRIPTION
add more summaries. change verbose sentences. fix broken small-pr.md link

- Added summary to pushback.md and speed.md for consistency
- Moved summary from bottom to top at looking-for.md for consistency
- Reworded confusing/verbose sentences in navigate.md and looking-for.md
- Fixed small-prs.md link in pr-descriptions.md broken by previous changes from CL to PR